### PR TITLE
Allow the user to set the hash

### DIFF
--- a/classic.go
+++ b/classic.go
@@ -113,3 +113,7 @@ func (b *BloomFilter) Reset() *BloomFilter {
 	b.buckets.Reset()
 	return b
 }
+
+func (b *BloomFilter) SetHash(h hash.Hash64) {
+	b.hash = h
+}


### PR DESCRIPTION
[Fnv](http://golang.org/pkg/hash/fnv/) is a nice and fast hash but in my experience it can result in a different false positive rate than expected. Below is the result of a test run I did to see if the expected false positive rate matches the actual rate (see code at the bottom of this pull request).

FNV:
```
$ time ./test
NewBloomFilter(      1000,  0.1%) =  0.0%
NewBloomFilter(     10000,  0.1%) =  0.4%
NewBloomFilter(  10000000,  0.1%) =  0.1%
NewBloomFilter(1000000000,  0.1%) =  1.6%
NewBloomFilter(      1000,  1.0%) =  0.0%
NewBloomFilter(     10000,  1.0%) =  0.4%
NewBloomFilter(  10000000,  1.0%) =  1.6%
NewBloomFilter(1000000000,  1.0%) =  1.4%
NewBloomFilter(      1000,  2.0%) =  0.0%
NewBloomFilter(     10000,  2.0%) =  3.2%
NewBloomFilter(  10000000,  2.0%) =  2.1%
NewBloomFilter(1000000000,  2.0%) =  1.2%
NewBloomFilter(      1000, 10.0%) = 28.5%
NewBloomFilter(     10000, 10.0%) = 11.2%
NewBloomFilter(  10000000, 10.0%) = 10.7%
NewBloomFilter(1000000000, 10.0%) =  8.5%

real	32m10.216s
user	25m2.260s
sys 	0m8.997s
```

Now I used this patch to set the hash to use the first 8 bytes from a Sha256 hash (see code below). As you can see this results in a much closer false positive rate than expected. Of course if you look at the runtime you see it took 6.5 times as much time because sha256 is much slower. This patch will give the user the option to make this trade-off themselves.

I only added the `SetHash` function to the classic hash since I wanted to see if you're interested in this pull request first. If you are I can also add it to the other filters and add some documentation about the trade-off between different hashes.

Sha256:
```
$ time ./test
NewBloomFilter(      1000,  0.1%) =  0.2%
NewBloomFilter(     10000,  0.1%) =  0.1%
NewBloomFilter(  10000000,  0.1%) =  0.1%
NewBloomFilter(1000000000,  0.1%) =  1.9%
NewBloomFilter(      1000,  1.0%) =  1.2%
NewBloomFilter(     10000,  1.0%) =  0.9%
NewBloomFilter(  10000000,  1.0%) =  1.0%
NewBloomFilter(1000000000,  1.0%) =  1.7%
NewBloomFilter(      1000,  2.0%) =  1.3%
NewBloomFilter(     10000,  2.0%) =  2.2%
NewBloomFilter(  10000000,  2.0%) =  2.0%
NewBloomFilter(1000000000,  2.0%) =  1.9%
NewBloomFilter(      1000, 10.0%) = 10.3%
NewBloomFilter(     10000, 10.0%) = 10.2%
NewBloomFilter(  10000000, 10.0%) = 10.2%
NewBloomFilter(1000000000, 10.0%) =  9.0%

real	219m5.628s
user	164m24.160s
sys 	1m6.653s
```

The program used to do this benchmark (at the moment using sha256):
```go
package main

import (
        "crypto/sha256"
        "encoding/binary"
        "fmt"
        "hash"
        "runtime"

        "github.com/erikdubbelboer/BoomFilters"
)

type hashwrap struct {
        hash.Hash
}

func (h hashwrap) Sum64() uint64 {
        b := h.Sum(nil)
        return binary.LittleEndian.Uint64(b[:8])
}

func main() {
        buf := make([]byte, 4)
        for _, f := range []float64{0.001, 0.01, 0.02, 0.1} {
                for _, n := range []uint{1000, 10000, 10000000, 1000000000} {
                        runtime.GC()

                        bf := boom.NewBloomFilter(n, f)
                        bf.SetHash(hashwrap{Hash: sha256.New()})

                        for i := uint(0); i < n; i++ {
                                binary.BigEndian.PutUint32(buf, uint32(i))
                                bf.Add(buf)
                        }

                        fp := 0
                        for i := uint(0); i < n; i++ {
                                binary.BigEndian.PutUint32(buf, uint32(i+n+1))
                                if bf.Test(buf) {
                                        fp++
                                }
                        }

                        fmt.Printf("NewBloomFilter(%10d, %4.1f%%) = %4.1f%%\n", n, f*100, (float64(fp)/float64(n))*100)
                }
        }
}
```