### PR TITLE
CMS serialization of matrix data

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,25 @@ func main() {
     fmt.Println("frequency of bob", cms.Count([]byte(`bob`)))
     fmt.Println("frequency of frank", cms.Count([]byte(`frank`)))
     
+
+    // Serialization example
+    buf := new(bytes.Buffer)
+    n, err := cms.WriteDataTo(buf)
+    if err != nil {
+       fmt.Println(err, n)
+    }
+
+    newCMS := boom.NewCountMinSketch(0.001, 0.99)
+    n, err = newCMS.ReadDataFrom(buf)
+    if err != nil {
+       fmt.Println(err, n)
+    }
+
+    fmt.Println("frequency of frank", cms.Count([]byte(`frank`)))
+
     // Restore to initial state.
     cms.Reset()
+
 }
 ```
 


### PR DESCRIPTION
Added simple cms serialization, tests, benchmarks and updated readme.
Could you review PR? if it is ok, I can add serialization to other filters.
```go
cms := boom.NewCountMinSketch(0.001, 0.99)

    cms.Add([]byte(`alice`)).Add([]byte(`bob`)).Add([]byte(`bob`)).Add([]byte(`frank`))
    fmt.Println("frequency of alice", cms.Count([]byte(`alice`)))
    fmt.Println("frequency of bob", cms.Count([]byte(`bob`)))
    fmt.Println("frequency of frank", cms.Count([]byte(`frank`)))


    // Serialization example
    buf := new(bytes.Buffer)
    n, err := cms.WriteDataTo(buf)
    if err != nil {
       fmt.Println(err, n)
    }

    newCMS := boom.NewCountMinSketch(0.001, 0.99)
    n, err = newCMS.ReadDataFrom(buf)
    if err != nil {
       fmt.Println(err, n)
    }

    fmt.Println("frequency of frank", cms.Count([]byte(`frank`)))
```