### PR TITLE
Adds serialization methods for ScalableBloomFilter, PartionedBloomFilter, and Buckets.

### DIFF
--- a/buckets_test.go
+++ b/buckets_test.go
@@ -1,6 +1,12 @@
 package boom
 
-import "testing"
+import (
+	"bytes"
+	"encoding/gob"
+	"testing"
+
+	"github.com/d4l3k/messagediff"
+)
 
 // Ensures that MaxBucketValue returns the correct maximum based on the bucket
 // size.
@@ -71,6 +77,28 @@ func TestBucketsReset(t *testing.T) {
 		if c := b.Get(uint(i)); c != 0 {
 			t.Errorf("Expected 0, got %d", c)
 		}
+	}
+}
+
+// Ensures that Buckets can be serialized and deserialized without errors.
+func TestBucketsGob(t *testing.T) {
+	b := NewBuckets(5, 2)
+	for i := 0; i < 5; i++ {
+		b.Increment(uint(i), 1)
+	}
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(b); err != nil {
+		t.Error(err)
+	}
+
+	b2 := NewBuckets(5, 2)
+	if err := gob.NewDecoder(&buf).Decode(b2); err != nil {
+		t.Error(err)
+	}
+
+	if diff, equal := messagediff.PrettyDiff(b, b2); !equal {
+		t.Errorf("Buckets Gob Encode and Decode = %+v; not %+v\n%s", b2, b, diff)
 	}
 }
 

--- a/scalable.go
+++ b/scalable.go
@@ -16,7 +16,10 @@ copies or substantial portions of the Software.
 package boom
 
 import (
+	"bytes"
+	"encoding/binary"
 	"hash"
+	"io"
 	"math"
 )
 
@@ -155,4 +158,102 @@ func (s *ScalableBloomFilter) SetHash(h hash.Hash64) {
 	for _, bf := range s.filters {
 		bf.SetHash(h)
 	}
+}
+
+// WriteTo writes a binary representation of the ScalableBloomFilter to an i/o stream.
+// It returns the number of bytes written.
+func (s *ScalableBloomFilter) WriteTo(stream io.Writer) (int64, error) {
+	err := binary.Write(stream, binary.BigEndian, s.r)
+	if err != nil {
+		return 0, err
+	}
+	err = binary.Write(stream, binary.BigEndian, s.fp)
+	if err != nil {
+		return 0, err
+	}
+	err = binary.Write(stream, binary.BigEndian, s.p)
+	if err != nil {
+		return 0, err
+	}
+	err = binary.Write(stream, binary.BigEndian, uint64(s.hint))
+	if err != nil {
+		return 0, err
+	}
+	err = binary.Write(stream, binary.BigEndian, uint64(len(s.filters)))
+	if err != nil {
+		return 0, err
+	}
+	var numBytes int64
+	for _, filter := range s.filters {
+		num, err := filter.WriteTo(stream)
+		if err != nil {
+			return 0, err
+		}
+		numBytes += num
+	}
+	return numBytes + int64(5*binary.Size(uint64(0))), err
+}
+
+// ReadFrom reads a binary representation of ScalableBloomFilter (such as might
+// have been written by WriteTo()) from an i/o stream. It returns the number
+// of bytes read.
+func (s *ScalableBloomFilter) ReadFrom(stream io.Reader) (int64, error) {
+	var r, fp, p float64
+	var hint, len uint64
+	err := binary.Read(stream, binary.BigEndian, &r)
+	if err != nil {
+		return 0, err
+	}
+	err = binary.Read(stream, binary.BigEndian, &fp)
+	if err != nil {
+		return 0, err
+	}
+	err = binary.Read(stream, binary.BigEndian, &p)
+	if err != nil {
+		return 0, err
+	}
+	err = binary.Read(stream, binary.BigEndian, &hint)
+	if err != nil {
+		return 0, err
+	}
+	err = binary.Read(stream, binary.BigEndian, &len)
+	if err != nil {
+		return 0, err
+	}
+	var numBytes int64
+	filters := make([]*PartitionedBloomFilter, len)
+	for i, _ := range filters {
+		filter := &PartitionedBloomFilter{}
+		num, err := filter.ReadFrom(stream)
+		if err != nil {
+			return 0, err
+		}
+		numBytes += num
+		filters[i] = filter
+	}
+	s.r = r
+	s.fp = fp
+	s.p = p
+	s.hint = uint(hint)
+	s.filters = filters
+	return numBytes + int64(5*binary.Size(uint64(0))), nil
+}
+
+// GobEncode implements gob.GobEncoder interface.
+func (s *ScalableBloomFilter) GobEncode() ([]byte, error) {
+	var buf bytes.Buffer
+	_, err := s.WriteTo(&buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
+}
+
+// GobDecode implements gob.GobDecoder interface.
+func (s *ScalableBloomFilter) GobDecode(data []byte) error {
+	buf := bytes.NewBuffer(data)
+	_, err := s.ReadFrom(buf)
+
+	return err
 }

--- a/scalable.go
+++ b/scalable.go
@@ -223,7 +223,7 @@ func (s *ScalableBloomFilter) ReadFrom(stream io.Reader) (int64, error) {
 	var numBytes int64
 	filters := make([]*PartitionedBloomFilter, len)
 	for i, _ := range filters {
-		filter := &PartitionedBloomFilter{}
+		filter := NewPartitionedBloomFilter(0, fp)
 		num, err := filter.ReadFrom(stream)
 		if err != nil {
 			return 0, err

--- a/scalable_test.go
+++ b/scalable_test.go
@@ -1,8 +1,12 @@
 package boom
 
 import (
+	"bytes"
+	"encoding/gob"
 	"strconv"
 	"testing"
+
+	"github.com/d4l3k/messagediff"
 )
 
 // Ensures that NewDefaultScalableBloomFilter creates a Scalable Bloom Filter
@@ -136,6 +140,28 @@ func TestScalableBloomReset(t *testing.T) {
 				t.Error("Expected all bits to be unset")
 			}
 		}
+	}
+}
+
+// Ensures that ScalableBloomFilter can be serialized and deserialized without errors.
+func TestScalableBloomGob(t *testing.T) {
+	f := NewScalableBloomFilter(10, 0.1, 0.8)
+	for i := 0; i < 1000; i++ {
+		f.Add([]byte(strconv.Itoa(i)))
+	}
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(f); err != nil {
+		t.Error(err)
+	}
+
+	f2 := NewScalableBloomFilter(10, 0.1, 0.8)
+	if err := gob.NewDecoder(&buf).Decode(f2); err != nil {
+		t.Error(err)
+	}
+
+	if diff, equal := messagediff.PrettyDiff(f, f2); !equal {
+		t.Errorf("ScalableBoomFilter Gob Encode and Decode = %+v; not %+v\n%s", f2, f, diff)
 	}
 }
 


### PR DESCRIPTION
Hey,

I added serialization methods for ScalableBloomFilter, PartionedBloomFilter, and Buckets. Let me know if you want different function names since they're slightly different from the CMS WriteDataTo and WriteDataFrom.

This is related to #6.

Thanks!