### PR TITLE
Fix GobDecode not setting a hash kernel for classic Bloom filters

### DIFF
--- a/classic.go
+++ b/classic.go
@@ -194,6 +194,9 @@ func (b *BloomFilter) GobEncode() ([]byte, error) {
 func (b *BloomFilter) GobDecode(data []byte) error {
 	buf := bytes.NewBuffer(data)
 	_, err := b.ReadFrom(buf)
+	if b.hash == nil {
+		b.hash = fnv.New64()
+	}
 
 	return err
 }

--- a/classic_test.go
+++ b/classic_test.go
@@ -147,7 +147,7 @@ func TestBloomFilter_EncodeDecode(t *testing.T) {
 		t.Error(err)
 	}
 
-	f2 := NewBloomFilter(100, 0.1)
+	f2 := &BloomFilter{}
 	if err := gob.NewDecoder(&buf).Decode(f2); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
The previous assumption, decoding were overwriting an existing and populated struct, falls apart when a struct with its default (empty) values were given. In practice this did break decoding into slices and maps such as `var all []*T; gob.NewDecoder(r).Decode(all)`.