### PR TITLE
Reduced memory allocs hashKernel, countMinSketch.Reset()

### DIFF
--- a/boom.go
+++ b/boom.go
@@ -37,7 +37,6 @@ into a bag of words.
 package boom
 
 import (
-	"encoding/binary"
 	"hash"
 	"math"
 )
@@ -77,7 +76,9 @@ func OptimalK(fpRate float64) uint {
 // hashes are derived.
 func hashKernel(data []byte, hash hash.Hash64) (uint32, uint32) {
 	hash.Write(data)
-	sum := hash.Sum(nil)
+	sum := hash.Sum64()
 	hash.Reset()
-	return binary.BigEndian.Uint32(sum[4:8]), binary.BigEndian.Uint32(sum[0:4])
+	upper := uint32(sum & 0xffffffff)
+	lower := uint32((sum >> 32) & 0xffffffff)
+	return upper, lower
 }

--- a/boom_test.go
+++ b/boom_test.go
@@ -1,0 +1,18 @@
+package boom
+
+import (
+	"encoding/binary"
+	"hash/fnv"
+	"testing"
+)
+
+func BenchmarkHashKernel(b *testing.B) {
+	hsh := fnv.New64()
+	var data [4]byte
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		binary.LittleEndian.PutUint32(data[:], uint32(i))
+		hashKernel(data[:], hsh)
+	}
+}

--- a/countmin.go
+++ b/countmin.go
@@ -133,12 +133,12 @@ func (c *CountMinSketch) Merge(other *CountMinSketch) error {
 // Reset restores the CountMinSketch to its original state. It returns itself
 // to allow for chaining.
 func (c *CountMinSketch) Reset() *CountMinSketch {
-	matrix := make([][]uint64, c.depth)
-	for i := uint(0); i < c.depth; i++ {
-		matrix[i] = make([]uint64, c.width)
+	for i := 0; i < len(c.matrix); i++ {
+		for j := 0; j < len(c.matrix[i]); j++ {
+			c.matrix[i][j] = 0
+		}
 	}
 
-	c.matrix = matrix
 	c.count = 0
 	return c
 }

--- a/countmin_test.go
+++ b/countmin_test.go
@@ -290,3 +290,13 @@ func BenchmarkCMSCount(b *testing.B) {
 		cms.Count(data[n])
 	}
 }
+
+func BenchmarkCMSReset(b *testing.B) {
+	b.StopTimer()
+	cms := NewCountMinSketch(0.0001, 0.1)
+	b.StartTimer()
+
+	for n := 0; n < b.N; n++ {
+		cms.Reset()
+	}
+}


### PR DESCRIPTION
## hashKernel

this method gets the upper/lower portions of the hash just using bitwise operations, instead of using a slice.

this reduces the allocs of this method to 0 

before:

```
$ go test -bench=. -benchmem boom.go boom_test.go
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
BenchmarkHashKernel-4           25947562                38.74 ns/op            8 B/op          1 allocs/op
PASS
```

after:

```
$ go test -bench=. -benchmem boom.go boom_test.go
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
BenchmarkHashKernel-4          80436614                12.77 ns/op            0 B/op          0 allocs/op
PASS
```

this should improve performance on methods that use this - e.g. countMinSketch Add/Count

before:

```
BenchmarkCMSAdd-4       19589024                69.54 ns/op            8 B/op          1 allocs/op
BenchmarkCMSCount-4     19352895                67.81 ns/op            8 B/op          1 allocs/op
```

after:

```
BenchmarkCMSAdd-4       41909880                31.24 ns/op            0 B/op          0 allocs/op
BenchmarkCMSCount-4     34261183                37.24 ns/op            0 B/op          0 allocs/op
```

## countMinSketch.Reset()

instead of creating a new matrix (which causes allocs), this re-uses the existing matrix and resets the counters to 0

before:

```
$ go test -bench=BenchmarkCMSReset -benchmem countmin.go countmin_test.go boom.go
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
BenchmarkCMSReset-4         9706            118053 ns/op          663632 B/op          4 allocs/op
PASS
```

after:

```
$ go test -bench=BenchmarkCMSReset -benchmem countmin.go countmin_test.go boom.go
goos: darwin
goarch: amd64
cpu: Intel(R) Core(TM) i5-5257U CPU @ 2.70GHz
BenchmarkCMSReset-4        14294             82448 ns/op               0 B/op          0 allocs/op
PASS
```