### PR TITLE
Fix hashKernel naming inconsistencies

### DIFF
--- a/boom.go
+++ b/boom.go
@@ -78,7 +78,7 @@ func hashKernel(data []byte, hash hash.Hash64) (uint32, uint32) {
 	hash.Write(data)
 	sum := hash.Sum64()
 	hash.Reset()
-	upper := uint32(sum & 0xffffffff)
-	lower := uint32((sum >> 32) & 0xffffffff)
-	return upper, lower
+	lower := uint32(sum & 0xffffffff)
+	upper := uint32((sum >> 32) & 0xffffffff)
+	return lower, upper
 }


### PR DESCRIPTION
The variable names ⁠upper and ⁠lower are inconsistent with what they actually contain:
- upper is taking the lower 32 bits of the hash (bits 0-31)
- ⁠lower is taking the upper 32 bits of the hash (bits 32-63)

Also, while `hashKernel` returns `upper, lower`, all the caller functions in the repo assign the return value to `lower, upper` - so I'm switching the return order.