### PR TITLE
Make reads thread-safe by not reusing hasher by default

### DIFF
--- a/boom.go
+++ b/boom.go
@@ -75,9 +75,7 @@ func OptimalK(fpRate float64) uint {
 // hashKernel returns the upper and lower base hash values from which the k
 // hashes are derived.
 func hashKernel(data []byte, hash hash.Hash64) (uint32, uint32) {
-	hash.Write(data)
-	sum := hash.Sum64()
-	hash.Reset()
+	sum := hash64DefaultFnv(data, hash)
 	lower := uint32(sum & 0xffffffff)
 	upper := uint32((sum >> 32) & 0xffffffff)
 	return lower, upper

--- a/boom_test.go
+++ b/boom_test.go
@@ -2,17 +2,15 @@ package boom
 
 import (
 	"encoding/binary"
-	"hash/fnv"
 	"testing"
 )
 
 func BenchmarkHashKernel(b *testing.B) {
-	hsh := fnv.New64()
 	var data [4]byte
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		binary.LittleEndian.PutUint32(data[:], uint32(i))
-		hashKernel(data[:], hsh)
+		hashKernel(data[:], nil)
 	}
 }

--- a/classic.go
+++ b/classic.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"hash"
-	"hash/fnv"
 	"io"
 	"math"
 )
@@ -25,7 +24,6 @@ func NewBloomFilter(n uint, fpRate float64) *BloomFilter {
 	m := OptimalM(n, fpRate)
 	return &BloomFilter{
 		buckets: NewBuckets(m, 1),
-		hash:    fnv.New64(),
 		m:       m,
 		k:       OptimalK(fpRate),
 	}
@@ -176,10 +174,7 @@ func (b *BloomFilter) ReadFrom(stream io.Reader) (int64, error) {
 	b.m = uint(m)
 	b.k = uint(k)
 	b.buckets = &buckets
-	// Initialize hash function if not set (same fix as in GobDecode)
-	if b.hash == nil {
-		b.hash = fnv.New64()
-	}
+
 	return readSize + int64(3*binary.Size(uint64(0))), nil
 }
 
@@ -198,9 +193,6 @@ func (b *BloomFilter) GobEncode() ([]byte, error) {
 func (b *BloomFilter) GobDecode(data []byte) error {
 	buf := bytes.NewBuffer(data)
 	_, err := b.ReadFrom(buf)
-	if b.hash == nil {
-		b.hash = fnv.New64()
-	}
 
 	return err
 }

--- a/counting.go
+++ b/counting.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"hash"
-	"hash/fnv"
 	"io"
 )
 
@@ -44,7 +43,6 @@ func NewCountingBloomFilter(n uint, b uint8, fpRate float64) *CountingBloomFilte
 	)
 	return &CountingBloomFilter{
 		buckets:     NewBuckets(m, b),
-		hash:        fnv.New64(),
 		m:           m,
 		k:           k,
 		indexBuffer: make([]uint, k),
@@ -247,9 +245,6 @@ func (b *CountingBloomFilter) GobEncode() ([]byte, error) {
 func (b *CountingBloomFilter) GobDecode(data []byte) error {
 	buf := bytes.NewBuffer(data)
 	_, err := b.ReadFrom(buf)
-	if b.hash == nil {
-		b.hash = fnv.New64()
-	}
 
 	return err
 }

--- a/countmin.go
+++ b/countmin.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"hash/fnv"
 	"io"
 	"math"
 )
@@ -60,7 +59,6 @@ func NewCountMinSketch(epsilon, delta float64) *CountMinSketch {
 		depth:   depth,
 		epsilon: epsilon,
 		delta:   delta,
-		hash:    fnv.New64(),
 	}
 }
 

--- a/cuckoo.go
+++ b/cuckoo.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"hash"
-	"hash/fnv"
 	"math"
 	"math/rand"
 )
@@ -86,7 +85,6 @@ func NewCuckooFilter(n uint, fpRate float64) *CuckooFilter {
 
 	return &CuckooFilter{
 		buckets: buckets,
-		hash:    fnv.New32(),
 		m:       m,
 		b:       b,
 		f:       f,
@@ -232,10 +230,7 @@ func (c *CuckooFilter) components(data []byte) (uint, uint, []byte) {
 
 // computeHash returns a 32-bit hash value for the given data.
 func (c *CuckooFilter) computeHash(data []byte) []byte {
-	c.hash.Write(data)
-	hash := c.hash.Sum(nil)
-	c.hash.Reset()
-	return hash
+	return hash32BytesDefaultFnv(data, c.hash)
 }
 
 // SetHash sets the hashing function used in the filter.

--- a/deletable.go
+++ b/deletable.go
@@ -2,7 +2,6 @@ package boom
 
 import (
 	"hash"
-	"hash/fnv"
 )
 
 // DeletableBloomFilter implements a Deletable Bloom Filter as described by
@@ -43,7 +42,6 @@ func NewDeletableBloomFilter(n, r uint, fpRate float64) *DeletableBloomFilter {
 	return &DeletableBloomFilter{
 		buckets:     NewBuckets(m-r, 1),
 		collisions:  NewBuckets(r+1, 1),
-		hash:        fnv.New64(),
 		m:           m - r,
 		regionSize:  (m - r) / r,
 		k:           k,

--- a/fnv.go
+++ b/fnv.go
@@ -51,7 +51,6 @@ func hash64DefaultFnv(data []byte, h hash.Hash64) uint64 {
 		h.Reset()
 		return sum
 	}
-	fnv.New64()
 
 	var sum uint64 = 14695981039346656037
 	for _, c := range data {

--- a/fnv.go
+++ b/fnv.go
@@ -1,0 +1,79 @@
+// Derived from Go's hash/fnv/fnv.go
+//
+// Copyright 2009 The Go Authors.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google LLC nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+
+package boom
+
+import (
+	"hash"
+	"hash/fnv"
+)
+
+const (
+	prime32 = 16777619
+	prime64 = 1099511628211
+)
+
+func hash32DefaultFnv(data []byte, h hash.Hash32) uint32 {
+	if h != nil {
+		h.Write(data)
+		sum := h.Sum32()
+		h.Reset()
+		return sum
+	}
+
+	var sum uint32 = 2166136261
+	for _, c := range data {
+		sum *= prime32
+		sum ^= uint32(c)
+	}
+	return sum
+}
+
+func hash64DefaultFnv(data []byte, h hash.Hash64) uint64 {
+	if h != nil {
+		h.Write(data)
+		sum := h.Sum64()
+		h.Reset()
+		return sum
+	}
+	fnv.New64()
+
+	var sum uint64 = 14695981039346656037
+	for _, c := range data {
+		sum *= prime64
+		sum ^= uint64(c)
+	}
+	return sum
+}
+
+func hash32BytesDefaultFnv(data []byte, h hash.Hash32) []byte {
+	if h != nil {
+		h.Write(data)
+		sum := h.Sum(nil)
+		h.Reset()
+		return sum
+	}
+
+	sum := hash32DefaultFnv(data, nil)
+	return append([]byte(nil),
+		byte(sum>>24),
+		byte(sum>>16),
+		byte(sum>>8),
+		byte(sum),
+	)
+}

--- a/fnv_test.go
+++ b/fnv_test.go
@@ -1,0 +1,53 @@
+package boom
+
+import (
+	"crypto/rand"
+	"hash/fnv"
+	"reflect"
+	"testing"
+)
+
+func TestHash32DefaultFnv(t *testing.T) {
+	var b []byte
+	rand.Read(b)
+
+	h := fnv.New32()
+	h.Write(b)
+	expected := h.Sum32()
+
+	got := hash32DefaultFnv(b, nil)
+
+	if expected != got {
+		t.Errorf("Expected %x, got %x", expected, got)
+	}
+}
+
+func TestHash64DefaultFnv(t *testing.T) {
+	var b []byte
+	rand.Read(b)
+
+	h := fnv.New64()
+	h.Write(b)
+	expected := h.Sum64()
+
+	got := hash64DefaultFnv(b, nil)
+
+	if expected != got {
+		t.Errorf("Expected %x, got %x", expected, got)
+	}
+}
+
+func TestHash32BytesDefaultFnv(t *testing.T) {
+	var b []byte
+	rand.Read(b)
+
+	h := fnv.New32()
+	h.Write(b)
+	expected := h.Sum(nil)
+
+	got := hash32BytesDefaultFnv(b, nil)
+
+	if !reflect.DeepEqual(expected, got) {
+		t.Errorf("Expected %x, got %x", expected, got)
+	}
+}

--- a/hyperloglog.go
+++ b/hyperloglog.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"hash"
-	"hash/fnv"
 	"io"
 	"math"
 )
@@ -68,7 +67,6 @@ func NewHyperLogLog(m uint) (*HyperLogLog, error) {
 		m:         m,
 		b:         uint32(math.Ceil(math.Log2(float64(m)))),
 		alpha:     calculateAlpha(m),
-		hash:      fnv.New32(),
 	}, nil
 }
 
@@ -148,10 +146,7 @@ func (h *HyperLogLog) Reset() *HyperLogLog {
 
 // calculateHash calculates the 32-bit hash value for the provided data.
 func (h *HyperLogLog) calculateHash(data []byte) uint32 {
-	h.hash.Write(data)
-	sum := h.hash.Sum32()
-	h.hash.Reset()
-	return sum
+	return hash32DefaultFnv(data, h.hash)
 }
 
 // SetHash sets the hashing function used.

--- a/partitioned.go
+++ b/partitioned.go
@@ -19,7 +19,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"hash"
-	"hash/fnv"
 	"io"
 	"math"
 )
@@ -59,7 +58,6 @@ func NewPartitionedBloomFilter(n uint, fpRate float64) *PartitionedBloomFilter {
 
 	return &PartitionedBloomFilter{
 		partitions: partitions,
-		hash:       fnv.New64(),
 		m:          m,
 		k:          k,
 		s:          s,

--- a/stable.go
+++ b/stable.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"hash"
-	"hash/fnv"
 	"io"
 	"math"
 	"math/rand"
@@ -57,7 +56,6 @@ func NewStableBloomFilter(m uint, d uint8, fpRate float64) *StableBloomFilter {
 	cells := NewBuckets(m, d)
 
 	return &StableBloomFilter{
-		hash:        fnv.New64(),
 		m:           m,
 		k:           k,
 		p:           optimalStableP(m, k, d, fpRate),
@@ -86,7 +84,6 @@ func NewUnstableBloomFilter(m uint, fpRate float64) *StableBloomFilter {
 	)
 
 	return &StableBloomFilter{
-		hash:        fnv.New64(),
 		m:           m,
 		k:           k,
 		p:           0,


### PR DESCRIPTION
We're seeing data race conditions when calling `CountMinSketch.Count`:

```
WARNING: DATA RACE
Read at 0x00c1515ff498 by goroutine 128:
  hash/fnv.(*sum64).Write()
      $GOROOT/src/hash/fnv/fnv.go:121 +0x36
  github.com/tylertreat/BoomFilters.hashKernel()
      /__w/vendor/github.com/tylertreat/BoomFilters/boom.go:78 +0x56
  github.com/tylertreat/BoomFilters.(*CountMinSketch).Count()
      /__w/vendor/github.com/tylertreat/BoomFilters/countmin.go:106 +0x7b

Previous write at 0x00c1515ff498 by goroutine 181:
  hash/fnv.(*sum64).Write()
      $GOROOT/src/hash/fnv/fnv.go:126 +0x98
  github.com/tylertreat/BoomFilters.hashKernel()
      /__w/vendor/github.com/tylertreat/BoomFilters/boom.go:78 +0x56
  github.com/tylertreat/BoomFilters.(*CountMinSketch).Count()
      /__w/vendor/github.com/tylertreat/BoomFilters/countmin.go:106 +0x7b
```

The race is on the `*sum64` receiver of the `hash/fnv.Write` method, and happens because the library stores the `*sum64`, wrapped in a `hash.Hash64`, instead of calling `fnv.New64` (and `fnv.New32`) afresh every time it needs to hash something. Concurrent hash operations will thus read-write from the same `*sum64`. This isn't thread-safe: hash operations will step on each other.

To avoid this, initially I changed the code to call `fnv.New64` for each hash operation. This, however, has a noticeable impact on performance, as a heap allocation needs to happen each time.

But really, this allocation doesn't need to exist to begin with: `sum64` is just a `uint64`, and it can be stack-allocated and passed around as one would with any word-sized value. It's really an unfortunate consequence of the design of `hash` that this isn't available out of the box, and we're forced to go through interfaces just to move uint64s around.

So instead, the (small) bits of code needed to implement FNV have been copied into plain, interface-less functions, and called by default, unless a custom `hash.Hash32/64` is provided.

Benchmarks:

<details><summary>With direct calls (pull request)</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/tylertreat/BoomFilters
cpu: Apple M4
                              │  base.bench   │               new.bench               │
                              │    sec/op     │    sec/op      vs base                │
HashKernel-10                    3.208n ±  0%   2.479n ±   1%  -22.72% (p=0.000 n=10)
BucketsIncrement-10              7.290n ±  0%   7.293n ±   0%        ~ (p=0.107 n=10)
BucketsSet-10                    4.245n ±  0%   4.246n ±   1%        ~ (p=0.697 n=10)
BucketsGet-10                    3.458n ±  0%   3.468n ±   8%   +0.29% (p=0.009 n=10)
BloomAdd-10                      16.79n ±  1%   16.08n ±   0%   -4.26% (p=0.000 n=10)
BloomTest-10                     6.691n ±  0%   6.272n ±   0%   -6.26% (p=0.000 n=10)
BloomTestAndAdd-10               21.03n ±  0%   21.11n ±   0%   +0.43% (p=0.000 n=10)
CountingAdd-10                   23.14n ±  1%   22.83n ±   1%   -1.32% (p=0.002 n=10)
CountingTest-10                  6.729n ±  2%   6.312n ±   0%   -6.19% (p=0.000 n=10)
CountingTestAndAdd-10            27.11n ±  0%   26.23n ±   0%   -3.23% (p=0.000 n=10)
CountingTestAndRemove-10         13.78n ±  0%   13.38n ±   0%   -2.94% (p=0.000 n=10)
CMSWriteDataTo-10                7.568µ ±  1%   7.598µ ±  12%        ~ (p=0.165 n=10)
CMSReadDataFrom-10               4.487µ ± 66%   4.624µ ±   2%        ~ (p=0.184 n=10)
CMSAdd-10                        6.301n ±  0%   5.571n ±   0%  -11.59% (p=0.000 n=10)
CMSCount-10                      7.843n ±  1%   7.341n ±   0%   -6.40% (p=0.000 n=10)
CMSReset-10                      30.42µ ±  0%   30.39µ ±   0%        ~ (p=0.342 n=10)
CuckooAdd-10                     320.2n ±  1%   337.5n ±   3%   +5.40% (p=0.000 n=10)
CuckooTest-10                    300.2n ± 71%   310.9n ±  72%        ~ (p=0.353 n=10)
CuckooTestAndAdd-10              91.58n ±  2%   91.46n ±   9%        ~ (p=0.953 n=10)
CuckooTestAndRemove-10           91.09n ±  8%   98.22n ± 454%   +7.82% (p=0.023 n=10)
DeletableAdd-10                  22.68n ±  0%   22.78n ±   0%   +0.42% (p=0.003 n=10)
DeletableTest-10                 6.426n ±  1%   5.904n ±   1%   -8.12% (p=0.000 n=10)
DeletableTestAndAdd-10           31.33n ±  0%   29.58n ±   0%   -5.57% (p=0.000 n=10)
DeletableTestAndRemove-10        13.54n ±  0%   12.90n ±   0%   -4.73% (p=0.000 n=10)
HllWriteDataTo-10                106.0n ±  0%   108.3n ±   1%   +2.22% (p=0.001 n=10)
HllReadDataFrom-10               62.36n ±  2%   62.93n ±   1%        ~ (p=0.306 n=10)
HLLCount4-10                     137.3n ±  1%   137.0n ±   1%        ~ (p=0.170 n=10)
HLLCount5-10                     289.9n ±  3%   286.7n ±   3%        ~ (p=0.280 n=10)
HLLCount6-10                     568.8n ±  1%   563.5n ±   1%   -0.93% (p=0.000 n=10)
HLLCount7-10                     1.170µ ±  2%   1.134µ ±   1%   -3.12% (p=0.000 n=10)
HLLCount8-10                     2.435µ ±  3%   2.322µ ±   0%   -4.66% (p=0.000 n=10)
HLLCount9-10                     5.236µ ±  9%   4.879µ ±   3%   -6.81% (p=0.020 n=10)
HLLCount10-10                    10.29µ ±  7%   10.42µ ±   5%        ~ (p=0.912 n=10)
InverseAdd-10                    30.03n ±  2%   22.74n ±   3%  -24.26% (p=0.000 n=10)
InverseTest-10                  12.435n ±  0%   6.550n ±   1%  -47.32% (p=0.000 n=10)
InverseTestAndAdd-10             40.35n ±  1%   31.15n ±   1%  -22.81% (p=0.000 n=10)
MinHash-10                       86.95m ±  1%   87.68m ±   0%   +0.84% (p=0.005 n=10)
PartitionedBloomAdd-10           16.20n ±  0%   16.60n ±   0%   +2.50% (p=0.000 n=10)
PartitionedBloomTest-10          6.704n ±  3%   6.194n ±   1%   -7.61% (p=0.000 n=10)
PartitionedBloomTestAndAdd-10    21.53n ±  0%   20.88n ±   0%   -2.97% (p=0.000 n=10)
ScalableBloomAdd-10              183.6n ±  1%   185.2n ±   0%   +0.87% (p=0.001 n=10)
ScalableBloomTest-10             7.498n ±  0%   6.671n ±   0%  -11.03% (p=0.000 n=10)
ScalableBloomTestAndAdd-10       890.4n ±  3%   898.5n ±   0%        ~ (p=1.000 n=10)
StableAdd-10                     56.59n ±  0%   56.11n ±   0%   -0.87% (p=0.000 n=10)
StableTest-10                    6.579n ±  0%   6.263n ±   0%   -4.80% (p=0.000 n=10)
StableTestAndAdd-10              72.04n ±  0%   72.56n ±   0%   +0.73% (p=0.002 n=10)
UnstableAdd-10                   24.05n ±  0%   22.57n ±   0%   -6.19% (p=0.000 n=10)
UnstableTest-10                  6.550n ±  1%   6.067n ±   1%   -7.36% (p=0.000 n=10)
UnstableTestAndAdd-10            28.77n ±  0%   28.14n ±   0%   -2.17% (p=0.000 n=10)
TopKAdd-10                       14.43n ±  0%   13.66n ±   0%   -5.37% (p=0.000 n=10)
geomean                          76.76n         73.12n          -4.74%

                   │  base.bench  │               new.bench               │
                   │     B/op     │     B/op      vs base                 │
CMSWriteDataTo-10    123.4Ki ± 1%   123.2Ki ± 1%       ~ (p=0.631 n=10)
CMSReadDataFrom-10   21.27Ki ± 0%   21.27Ki ± 0%       ~ (p=1.000 n=10) ¹
HllWriteDataTo-10      828.5 ± 1%     839.5 ± 1%  +1.33% (p=0.000 n=10)
HllReadDataFrom-10     152.0 ± 0%     152.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean              4.214Ki        4.226Ki       +0.28%
¹ all samples are equal

                   │ base.bench │              new.bench              │
                   │ allocs/op  │ allocs/op   vs base                 │
CMSWriteDataTo-10    7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=10) ¹
CMSReadDataFrom-10   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
HllWriteDataTo-10    6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=10) ¹
HllReadDataFrom-10   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean              5.091        5.091       +0.00%
¹ all samples are equal
```
</details>

<details><summary>With indirect calls through new hasher per operation (discarded option)</summary>

```
goos: darwin
goarch: arm64
pkg: github.com/tylertreat/BoomFilters
cpu: Apple M4
                              │  base.bench   │              iface.bench               │
                              │    sec/op     │    sec/op      vs base                 │
HashKernel-10                    3.208n ±  0%    9.258n ±  2%  +188.59% (p=0.000 n=10)
BucketsIncrement-10              7.290n ±  0%    7.281n ±  0%         ~ (p=0.224 n=10)
BucketsSet-10                    4.245n ±  0%    4.236n ±  0%    -0.21% (p=0.008 n=10)
BucketsGet-10                    3.458n ±  0%    3.449n ±  0%    -0.26% (p=0.000 n=10)
BloomAdd-10                      16.79n ±  1%    21.85n ±  1%   +30.10% (p=0.000 n=10)
BloomTest-10                     6.691n ±  0%   12.125n ±  2%   +81.23% (p=0.000 n=10)
BloomTestAndAdd-10               21.03n ±  0%    27.33n ±  1%   +29.99% (p=0.000 n=10)
CountingAdd-10                   23.14n ±  1%    27.51n ±  3%   +18.91% (p=0.000 n=10)
CountingTest-10                  6.729n ±  2%   12.340n ±  2%   +83.39% (p=0.000 n=10)
CountingTestAndAdd-10            27.11n ±  0%    31.55n ±  2%   +16.38% (p=0.000 n=10)
CountingTestAndRemove-10         13.78n ±  0%    18.83n ±  2%   +36.61% (p=0.000 n=10)
CMSWriteDataTo-10                7.568µ ±  1%    7.443µ ± 24%         ~ (p=0.393 n=10)
CMSReadDataFrom-10               4.487µ ± 66%    6.984µ ± 31%   +55.66% (p=0.050 n=10)
CMSAdd-10                        6.301n ±  0%   12.350n ±  3%   +96.02% (p=0.000 n=10)
CMSCount-10                      7.843n ±  1%   15.500n ±  1%   +97.63% (p=0.000 n=10)
CMSReset-10                      30.42µ ±  0%    30.35µ ±  0%    -0.23% (p=0.016 n=10)
CuckooAdd-10                     320.2n ±  1%    398.7n ±  5%   +24.50% (p=0.000 n=10)
CuckooTest-10                   300.15n ± 71%    94.58n ±  5%   -68.49% (p=0.009 n=10)
CuckooTestAndAdd-10              91.58n ±  2%    97.19n ±  1%    +6.13% (p=0.000 n=10)
CuckooTestAndRemove-10           91.09n ±  8%    95.62n ±  2%    +4.97% (p=0.019 n=10)
DeletableAdd-10                  22.68n ±  0%    26.70n ±  1%   +17.72% (p=0.000 n=10)
DeletableTest-10                 6.426n ±  1%   12.165n ±  2%   +89.29% (p=0.000 n=10)
DeletableTestAndAdd-10           31.33n ±  0%    35.15n ±  1%   +12.21% (p=0.000 n=10)
DeletableTestAndRemove-10        13.54n ±  0%    18.16n ±  3%   +34.08% (p=0.000 n=10)
HllWriteDataTo-10                106.0n ±  0%    104.2n ±  1%    -1.70% (p=0.001 n=10)
HllReadDataFrom-10               62.36n ±  2%    65.50n ±  6%    +5.04% (p=0.042 n=10)
HLLCount4-10                     137.3n ±  1%    126.0n ±  1%    -8.23% (p=0.000 n=10)
HLLCount5-10                     289.9n ±  3%    266.2n ±  2%    -8.17% (p=0.000 n=10)
HLLCount6-10                     568.8n ±  1%    536.1n ±  6%    -5.74% (p=0.000 n=10)
HLLCount7-10                     1.170µ ±  2%    1.049µ ±  5%   -10.34% (p=0.000 n=10)
HLLCount8-10                     2.435µ ±  3%    2.239µ ±  2%    -8.05% (p=0.000 n=10)
HLLCount9-10                     5.236µ ±  9%    4.425µ ±  2%   -15.48% (p=0.000 n=10)
HLLCount10-10                   10.289µ ±  7%    9.247µ ±  9%   -10.12% (p=0.002 n=10)
InverseAdd-10                    30.03n ±  2%    29.20n ±  1%    -2.76% (p=0.000 n=10)
InverseTest-10                   12.44n ±  0%    14.08n ±  3%   +13.23% (p=0.000 n=10)
InverseTestAndAdd-10             40.35n ±  1%    37.75n ±  1%    -6.44% (p=0.000 n=10)
MinHash-10                       86.95m ±  1%    80.53m ±  2%    -7.38% (p=0.000 n=10)
PartitionedBloomAdd-10           16.20n ±  0%    21.95n ±  1%   +35.50% (p=0.000 n=10)
PartitionedBloomTest-10          6.704n ±  3%   12.035n ±  3%   +79.53% (p=0.000 n=10)
PartitionedBloomTestAndAdd-10    21.53n ±  0%    26.95n ±  2%   +25.23% (p=0.000 n=10)
ScalableBloomAdd-10              183.6n ±  1%    155.3n ±  1%   -15.39% (p=0.000 n=10)
ScalableBloomTest-10             7.498n ±  0%   12.730n ±  3%   +69.78% (p=0.000 n=10)
ScalableBloomTestAndAdd-10       890.4n ±  3%    855.4n ±  2%    -3.93% (p=0.000 n=10)
StableAdd-10                     56.59n ±  0%    63.02n ±  3%   +11.34% (p=0.000 n=10)
StableTest-10                    6.579n ±  0%   12.180n ±  1%   +85.13% (p=0.000 n=10)
StableTestAndAdd-10              72.04n ±  0%    81.65n ±  1%   +13.35% (p=0.000 n=10)
UnstableAdd-10                   24.05n ±  0%    27.86n ±  3%   +15.80% (p=0.000 n=10)
UnstableTest-10                  6.550n ±  1%   12.340n ±  3%   +88.41% (p=0.000 n=10)
UnstableTestAndAdd-10            28.77n ±  0%    34.08n ±  1%   +18.46% (p=0.000 n=10)
TopKAdd-10                       14.43n ±  0%    31.82n ±  1%  +120.55% (p=0.000 n=10)
geomean                          76.76n          91.69n         +19.46%

                   │  base.bench  │              iface.bench              │
                   │     B/op     │     B/op      vs base                 │
CMSWriteDataTo-10    123.4Ki ± 1%   121.0Ki ± 1%  -1.95% (p=0.002 n=10)
CMSReadDataFrom-10   21.27Ki ± 0%   21.27Ki ± 0%       ~ (p=1.000 n=10) ¹
HllWriteDataTo-10      828.5 ± 1%     819.0 ± 1%  -1.15% (p=0.005 n=10)
HllReadDataFrom-10     152.0 ± 0%     152.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean              4.214Ki        4.181Ki       -0.78%
¹ all samples are equal

                   │ base.bench │             iface.bench             │
                   │ allocs/op  │ allocs/op   vs base                 │
CMSWriteDataTo-10    7.000 ± 0%   7.000 ± 0%       ~ (p=1.000 n=10) ¹
CMSReadDataFrom-10   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
HllWriteDataTo-10    6.000 ± 0%   6.000 ± 0%       ~ (p=1.000 n=10) ¹
HllReadDataFrom-10   4.000 ± 0%   4.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean              5.091        5.091       +0.00%
¹ all samples are equal
```
</details>