### PR TITLE
Remove unused import

### DIFF
--- a/fnv.go
+++ b/fnv.go
@@ -20,7 +20,6 @@ package boom
 
 import (
 	"hash"
-	"hash/fnv"
 )
 
 const (


### PR DESCRIPTION
Follow up of #43.

I accidentally left behind an unused import, which is now making CI fail on our repo.